### PR TITLE
Changed ednpoint params, body not required for favorites.

### DIFF
--- a/api/customer_favs/customerFavRouter.js
+++ b/api/customer_favs/customerFavRouter.js
@@ -11,7 +11,7 @@ router.all('/', function (req, res, next) {
 /******************************************************************************
  *                      GET ALL customer fav's by user id
  ******************************************************************************/
-router.get('/', authRequired,  async (req, res) => {
+router.get('/', authRequired, async (req, res) => {
   try {
     const { customer_id: id } = req.params;
 
@@ -29,7 +29,7 @@ router.get('/', authRequired,  async (req, res) => {
 
 router.post('/:groom_id', authRequired, async (req, res) => {
   try {
-    const { customer_id, groom_id} = req.params;
+    const { customer_id, groom_id } = req.params;
 
     if (!groom_id) {
       return res.status(404).json({ message: 'Missing required id(groomer).' });

--- a/api/customer_favs/customerFavRouter.js
+++ b/api/customer_favs/customerFavRouter.js
@@ -11,7 +11,7 @@ router.all('/', function (req, res, next) {
 /******************************************************************************
  *                      GET ALL customer fav's by user id
  ******************************************************************************/
-router.get('/', authRequired, async (req, res) => {
+router.get('/', authRequired,  async (req, res) => {
   try {
     const { customer_id: id } = req.params;
 
@@ -27,10 +27,9 @@ router.get('/', authRequired, async (req, res) => {
  *                      POST customer favorite by ID
  ******************************************************************************/
 
-router.post('/', authRequired, async (req, res) => {
+router.post('/:groom_id', authRequired, async (req, res) => {
   try {
-    const { customer_id } = req.params;
-    const { groom_id } = req.body;
+    const { customer_id, groom_id} = req.params;
 
     if (!groom_id) {
       return res.status(404).json({ message: 'Missing required id(groomer).' });
@@ -70,10 +69,9 @@ router.post('/', authRequired, async (req, res) => {
 /******************************************************************************
  *                      DELETE customer favorite by ID
  ******************************************************************************/
-router.delete('/', authRequired, async (req, res) => {
+router.delete('/:groom_id', authRequired, async (req, res) => {
   try {
-    const { customer_id } = req.params;
-    const { groom_id } = req.body;
+    const { customer_id, groom_id } = req.params;
 
     const findGroom = await favs.findGroom(groom_id);
 


### PR DESCRIPTION
## Description ##

Updated Customer favorites to use all params rather than body for ease of use.
EX: http://localhost:8000/customers/00ultwz1n9ORpNFc04x6/favorites/00ulthapbErVUwVJy4x6 <--(GroomerID) for posting a new fav

## Type ##

- [ ] This is a bugfix.
- [ ] This is a new feature.
- [x ] This is part of a feature.


## Review ##

- [ ] Is this a work in progress?
- [x ] Is this ready to be reviewed?
- [ ] Have you added two reviewers to this pull request?
